### PR TITLE
Update bindcraft.py to fix mpnn counter

### DIFF
--- a/bindcraft.py
+++ b/bindcraft.py
@@ -230,6 +230,7 @@ while True:
                         # if AF2 filters are not passed then skip the scoring
                         if not pass_af2_filters:
                             print(f"Base AF2 filters not passed for {mpnn_design_name}, skipping interface scoring")
+                            mpnn_n += 1
                             continue
 
                         # calculate statistics for each model individually


### PR DESCRIPTION
#74 related tiny pull request. I noticed that if base alphafold filter weren't met, the MPNN counter didn't update. Pretty sure it's just because of the continue statement preventing the counter update from executing. Otherwise new sequences are being tested, so no other changes necessary. I didn't look too hard at this, but it's a small enough fix it (hopefully) shouldn't break anything. 