### PR TITLE
Adding custom Trajectory rejection thresholds using advanced settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ weights_rg                      -> Design weight - radius of gyration weight for
 use_termini_distance_loss       -> Try to minimise distance between N- and C-terminus of binder? Helpful for grafting
 weights_termini_loss            -> Design weight - N- and C-terminus distance minimisation weight of binder
 
+# Trajectory quality thresholds
+trajectory_max_ca_clashes       -> Maximum number of CA clashes allowed before discarding trajectory as Clashing (default: 0)
+trajectory_min_plddt            -> Minimum final pLDDT required to keep trajectory, below this it is marked LowConfidence (default: 0.7)
+trajectory_min_contacts         -> Minimum number of interface contacts required, below this trajectory is marked LowConfidence (default: 3)
+
 # MPNN settings
 mpnn_fix_interface              -> whether to fix the interface designed in the starting trajectory
 num_seqs                        -> number of MPNN generated sequences to sample and predict per binder

--- a/functions/colabdesign_utils.py
+++ b/functions/colabdesign_utils.py
@@ -184,14 +184,14 @@ def binder_hallucination(design_name, starting_pdb, chain, target_hotspot_residu
     ca_clashes = calculate_clash_score(model_pdb_path, 2.5, only_ca=True)
 
     #if clash_interface > 25 or ca_clashes > 0:
-    if ca_clashes > 0:
+    if ca_clashes > advanced_settings.get("trajectory_max_ca_clashes", 0):
         af_model.aux["log"]["terminate"] = "Clashing"
         update_failures(failure_csv, 'Trajectory_Clashes')
         print("Severe clashes detected, skipping analysis and MPNN optimisation")
         print("")
     else:
         # check if low quality prediction
-        if final_plddt < 0.7:
+        if final_plddt < advanced_settings.get("trajectory_min_plddt", 0.7):
             af_model.aux["log"]["terminate"] = "LowConfidence"
             update_failures(failure_csv, 'Trajectory_final_pLDDT')
             print("Trajectory starting confidence low, skipping analysis and MPNN optimisation")
@@ -202,7 +202,7 @@ def binder_hallucination(design_name, starting_pdb, chain, target_hotspot_residu
             binder_contacts_n = len(binder_contacts.items())
 
             # if less than 3 contacts then protein is floating above and is not binder
-            if binder_contacts_n < 3:
+            if binder_contacts_n < advanced_settings.get("trajectory_min_contacts", 3):
                 af_model.aux["log"]["terminate"] = "LowConfidence"
                 update_failures(failure_csv, 'Trajectory_Contacts')
                 print("Too few contacts at the interface, skipping analysis and MPNN optimisation")


### PR DESCRIPTION
Adding option to customize Trajectory rejection thresholds by using 3 new arguments in advanced settings json file.

The arguments are:
 - `trajectory_max_ca_clashes` - Maximum number of CA clashes allowed before discarding trajectory as Clashing (default: 0)
- `trajectory_min_plddt` - Minimum final pLDDT required to keep trajectory, below this it is marked LowConfidence (default: 0.7)
- `trajectory_min_contacts` - Minimum number of interface contacts required, below this trajectory is marked LowConfidence (default: 3)
