### PR TITLE
Support PyRosetta DockingPartners API

### DIFF
--- a/functions/pyrosetta_utils.py
+++ b/functions/pyrosetta_utils.py
@@ -23,7 +23,11 @@ def score_interface(pdb_file, binder_chain="B"):
 
     # analyze interface statistics
     iam = InterfaceAnalyzerMover()
-    iam.set_interface("A_B")
+    interface = "A_B"
+    docking_partners_type = getattr(pr.rosetta.core.pose, "DockingPartners", None)
+    if docking_partners_type is not None:
+        interface = docking_partners_type.docking_partners_from_string(interface)
+    iam.set_interface(interface)
     scorefxn = pr.get_fa_scorefxn()
     iam.set_scorefunction(scorefxn)
     iam.set_compute_packstat(True)


### PR DESCRIPTION
## Summary

- Convert the `"A_B"` interface string to a `DockingPartners` object when that API is available.
- Retain the legacy string path for compatibility with older PyRosetta builds.

## Why

Rosetta changed interface specifications in June 2026 to use `core::pose::DockingPartners`, primarily to support multi-character mmCIF chain IDs. Starting with PyRosetta 2026.26, `InterfaceAnalyzerMover.set_interface()` no longer accepts a plain string. Because BindCraft installs PyRosetta without a version pin, new environments can fail during interface scoring.

This compatibility shim preserves the existing `A_B` semantics while allowing both older and current PyRosetta releases to run.

Upstream API change: https://github.com/RosettaCommons/rosetta/commit/2624daeacb8a57b70a6ce46f0e399894241409fb

## Validation

- `python3 -m py_compile functions/pyrosetta_utils.py`
- `git diff --check`

PyRosetta runtime validation was not available in the local development environment.
